### PR TITLE
fix(ci): add fetch-depth and lfs to hf deployment step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
fixes 'shallow update not allowed' error when pushing to hugging face spaces. the deploy-to-hf job needs full git history and lfs support to push successfully. match the configuration used in manual hf-space.yml workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure the Hugging Face deploy job’s checkout to use full git history and LFS support to avoid push failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db61e48b30d9c56acfa23691b7dfe2c4e505a0c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->