### PR TITLE
Run 'vite build' in the build step.

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,0 +1,59 @@
+name: Release & Deploy - Github Only
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --no-frozen-lockfile --recursive
+
+      - name: Build Packages
+        run: pnpm run build:all
+
+      - name: Zip packages
+        run: |
+          cd packages
+          zip -r ../cli-dist.zip cli/dist cli/package.json
+          zip -r ../node-dist.zip node/dist node/package.json
+          zip -r ../web-dist.zip web/dist web/package.json
+          cd ..
+          zip -r release-all.zip packages/cli/dist packages/cli/package.json packages/node/dist packages/node/package.json packages/web/dist packages/web/package.json
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            cli-dist.zip
+            node-dist.zip
+            web-dist.zip
+            release-all.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,7 +35,7 @@
     "typescript"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "vite build && tsc --project tsconfig.build.json --emitDeclarationOnly",
     "watch": "tsc --project tsconfig.build.json --watch",
     "lint": "eslint src --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   build: {
     lib: {
       entry: "./src/index.ts",
-      formats: ["es"],
+      formats: ["es"], fileName: "index"
     },
     rollupOptions: {
       external: ["typescript"],


### PR DESCRIPTION
When emitting raw ES modules, the relative paths outputted in dist/record.js can't find the generateREADME file.

This change generates a single web.js file that addresses all the relative imports.